### PR TITLE
Add debug for urls in XML sitemaps

### DIFF
--- a/pkg/checker/workers.go
+++ b/pkg/checker/workers.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/bythepixel/urlchecker/pkg/client"
+	"github.com/bythepixel/urlchecker/pkg/config"
 )
 
 var maxErrors uint64 = 5
@@ -20,6 +21,10 @@ func XMLWorker(ctx context.Context, cancel context.CancelFunc, urlChan chan stri
 		case url, ok := <-urlChan:
 			if !ok {
 				return
+			}
+
+			if config.Debug {
+				log.Printf("Checking %s...", url)
 			}
 
 			status, _, err := client.Fetch(url)


### PR DESCRIPTION
Currently, if the `DEBUG` environment variable is set, it'll only tell you which url it's checking for the initial urls. It doesn't tell you which url in the XML file within those urls it's checking, which would be incredibly useful